### PR TITLE
Adds js true for more details expanding section

### DIFF
--- a/spec/features/create_petition_spec.rb
+++ b/spec/features/create_petition_spec.rb
@@ -85,12 +85,14 @@ RSpec.describe 'Create Petition', type: :feature do
       end
     end
 
-    it 'remembers users input when going back a stage' do
+    it 'remembers users input when going back a stage', js: true do
       visit new_petition_url
       fill_in_start_petition_step_with(petition)
 
       expect(page).to have_css('h1', 'Check your petition')
       expect(page).to have_text petition[:action]
+
+      expect(page).not_to have_text petition[:additional_detail]
 
       find(:xpath, "//details/summary[contains(., 'More details')]").click
       expect(page).to have_text petition[:additional_detail]


### PR DESCRIPTION
It was originally a javascript test in cucumber and migrated without the js metadata, therefore added a check that the expected text isn't visible which failed and correctly added the js metadata for a correct pass.
