### PR TITLE
Job to send new privacy policy email

### DIFF
--- a/app/jobs/deliver_privacy_policy_update_job.rb
+++ b/app/jobs/deliver_privacy_policy_update_job.rb
@@ -1,0 +1,6 @@
+class DeliverPrivacyPolicyUpdateJob < EmailJob
+  queue_as :low_priority
+
+  self.mailer = PetitionMailer
+  self.email = :privacy_policy_update_email
+end

--- a/app/jobs/email_privacy_policy_update_job.rb
+++ b/app/jobs/email_privacy_policy_update_job.rb
@@ -1,0 +1,34 @@
+class EmailPrivacyPolicyUpdateJob < ApplicationJob
+  queue_as :low_priority
+
+  def perform(petition)
+    terminating = false
+
+    worker = trap("TERM") do
+      terminating = true
+      worker.call
+    end
+
+    Appsignal.without_instrumentation do
+      petition.signatures.validated.find_each do |signature|
+        privacy_notification = PrivacyNotification.create!(id: signature.uuid)
+        DeliverPrivacyPolicyUpdateJob.perform_later(privacy_notification)
+
+        if terminating
+          reschedule_job(petition)
+          return true
+        end
+      rescue ActiveRecord::RecordNotUnique
+        next
+      end
+    end
+  ensure
+    trap("TERM", worker)
+  end
+
+  private
+
+  def reschedule_job(petition)
+    self.class.set(wait_until: 5.minutes.from_now).perform_later(petition)
+  end
+end

--- a/app/jobs/email_privacy_policy_updates_job.rb
+++ b/app/jobs/email_privacy_policy_updates_job.rb
@@ -1,0 +1,9 @@
+class EmailPrivacyPolicyUpdatesJob < ApplicationJob
+  queue_as :high_priority
+
+  def perform
+    Petition.not_anonymized.moderated.find_each do |petition|
+      EmailPrivacyPolicyUpdateJob.perform_later(petition)
+    end
+  end
+end

--- a/app/jobs/email_privacy_policy_updates_job.rb
+++ b/app/jobs/email_privacy_policy_updates_job.rb
@@ -1,8 +1,8 @@
 class EmailPrivacyPolicyUpdatesJob < ApplicationJob
   queue_as :high_priority
 
-  def perform
-    Petition.not_anonymized.moderated.find_each do |petition|
+  def perform(time:)
+    Petition.where(created_at: time..).find_each do |petition|
       EmailPrivacyPolicyUpdateJob.perform_later(petition)
     end
   end

--- a/app/mailers/petition_mailer.rb
+++ b/app/mailers/petition_mailer.rb
@@ -182,6 +182,17 @@ class PetitionMailer < ApplicationMailer
       list_unsubscribe: unsubscribe_url
   end
 
+  def privacy_policy_update_email(privacy_notification)
+    @name = privacy_notification.name
+    @petitions = privacy_notification.petitions
+    @remaining_petition_count = privacy_notification.remaining_petition_count
+
+    mail(
+      to: privacy_notification.email,
+      subject: subject_for(:privacy_policy_update_email)
+    )
+  end
+
   private
 
   def subject_for(key, options = {})

--- a/app/models/privacy_notification.rb
+++ b/app/models/privacy_notification.rb
@@ -1,0 +1,16 @@
+class PrivacyNotification < ActiveRecord::Base
+  PETITION_LIMIT = 5
+  PETITION_SCOPE = lambda {
+    not_anonymized.moderated.distinct.by_most_recent.limit(PETITION_LIMIT)
+  }
+
+  has_one :signature, foreign_key: :uuid
+  has_many :signatures, -> { validated }, foreign_key: :uuid
+  has_many :petitions, PETITION_SCOPE, through: :signatures
+
+  delegate :name, :email, to: :signature
+
+  def remaining_petition_count
+    [petitions.limit(nil).count - PETITION_LIMIT, 0].max
+  end
+end

--- a/app/views/petition_mailer/privacy_policy_update_email.html.erb
+++ b/app/views/petition_mailer/privacy_policy_update_email.html.erb
@@ -1,0 +1,223 @@
+<p>Dear <%= @name %></p>
+
+<p>
+  We're getting in touch to let you know we’re making changes to the privacy notice for the UK Government and Parliament Petitions site (<%= link_to(nil, home_url) %>)on 1st March 2022. We are contacting you to make you aware of these changes because you have started/signed the following petitions that will be affected by these changes:
+</p>
+
+<% @petitions.each do |petition| %>
+  <p>
+    <strong><%= petition.action %></strong>
+    <br>
+    <%= link_to(nil, petition_url(petition)) %>
+  </p>
+<% end %>
+
+<% if @remaining_petition_count > 0 %>
+  <p>
+    Plus another
+    <%= pluralize(@remaining_petition_count, "petition", locale: :en) %>
+  </p>
+<% end %>
+
+<p>
+  We retain your personal data for as long as is necessary for the purpose it was collected.  We will never share or sell your personal data to other organisations for direct marketing purposes.
+</p>
+
+<p>What's changing and why?</p>
+
+<ul>
+  <li>
+    The privacy notice has been updated. This is to ensure the privacy notice is up to date and complies with all relevant legislation, including the United Kingdom General Data Protection Regulation (UK GDPR) and Data Protection Act 2018.
+  </li>
+  <li>
+    The House of Commons is now the sole data controller for the site. This update reflects the way that your data is stored and used.
+  </li>
+  <li>
+    Information about cookies has been moved to a new page at <%= link_to(nil, cookies_url) %>.
+  </li>
+  <li>
+    How long we keep your data.  Personal data was kept for 6 months after a petition closed, but this has meant that the Petitions Committee hasn't been able to contact petitioners who opt-in to updates about their petitions when a debate has been scheduled or when other relevant Parliamentary business has taken place more than 6 months after a petition closed. This update means that from 1st March 2022, we will hold your personal data for six months after the dissolution of the current Parliament. Your data protection rights are not affected by this change and you can exercise those rights at any time as detailed in the privacy notice.
+  </li>
+</ul>
+
+<p>
+  You can read the updated privacy notice below or at <%= link_to(nil, privacy_url) %> from 1st March 2022. This includes information about how to contact us.
+</p>
+
+<p>
+  <%= t("petitions.emails.signoff_prefix") %>
+  <br>
+  <%= t("petitions.emails.signoff_suffix") %>
+</p>
+
+<h1>Privacy Notice</h1>
+
+<p>
+  We respect your right to privacy and managed your personal data in line with our responsibilities under the United Kingdom General Data Protection Regulation (UK GDPR) and Data Protection Act 2018 (DPA 2018) . This privacy notice provides the information required by the UK GDPR about the personal data that we collect from you and how we may use your information.
+</p>
+
+<p>
+  In this notice, references to 'us', 'our' or 'we' are to the House of Commons; and to ‘you’ or ‘your’ are to an individual whose personal data we process.
+</p>
+
+<p>
+  Everything that we do with your personal data – for example, collecting, storing, using, sharing or deleting it – is referred to as 'processing'.
+</p>
+
+<p>
+  This notice will be updated periodically.  We will communicate any significant changes as appropriate.
+</p>
+
+<h2>1. About us</h2>
+
+<p>
+  The Corporate Officer of the House of Commons (the Clerk of the House) is the Controller of any personal data processed as described in this Privacy Notice.
+</p>
+
+<p>
+  The House of Commons Data Protection Officer is the Head of Information Rights and Information Security (IRIS).
+</p>
+
+<p>
+  If you have any questions about the use of your personal data, please contact IRIS:
+</p>
+
+<ul>
+  <li>Email: <%= mail_to("IRIS@parliament.uk") %></li>
+  <li>Telephone: 0207 219 4296</li>
+  <li>Post: IRIS Service, House of Commons, SW1A 0AA</li>
+</ul>
+
+<h2>2. The personal data we process</h2>
+
+<p>
+  When you contact us, visit us, access or use our services either online, by post, in person or by other means, we may collect, store and use your personal data.
+</p>
+
+<p>
+  The personal data we collect from people who start and sign petitions will include: your name, your email address, your postcode, the country you live in, whether you are a British citizen, the IP address you use when starting or signing a petition.
+</p>
+
+<h2>3. Use of your personal data</h2>
+
+<p>
+  The Petitions service is provided by the House of Commons. Your personal data will be processed for the purposes of starting and signing petitions to raise issues with the UK Government and Parliament.
+</p>
+
+<p>We use your personal data to:</p>
+
+<ul>
+  <li>check that you're eligible to sign a petition</li>
+  <li>make sure that people only sign a petition once</li>
+  <li>contact you about petitions you start</li>
+  <li>with your consent, we may send you updates about petitions you have signed.</li>
+</ul>
+
+<p>
+  If you start a petition and we accept it, your name will be published with the petition. We won’t publish any other personal information about you. If you’ve signed a petition, we won’t publish any personal information about you. We’ll use your postcode to work out how many people in each parliamentary constituency have signed a petition.
+</p>
+
+<p>
+  For the purpose of petitions, we consider that the lawful basis for processing your data is that we are engaged in a public task.  The processing is necessary for the performance of a public task, namely the exercise of a function of the House of Commons (UK GDPR Article 6 (1) (e) and DPA 2018 (8)).  Specifically, processing this data is necessary for the e-petitions website and the work of the Petitions Committee.
+</p>
+
+<p>
+  For the purpose of informing you about the status of petitions, we rely on your consent to send updates to an email address provided by you (UK GDPR Article 6(1)(a)).
+</p>
+
+<p>
+  Whilst there is no requirement to provide special category data, any information you provide which includes racial or ethnic origin; religious or philosophical beliefs; trade union membership; genetic and biometric data; health data; sex life or sexual orientation will be considered necessary for reasons of substantial public interest, namely the exercise of a function of the House of Commons (UK GDPR Article 9 (2)(g) and DPA 2018 Schedule 1 (7)(b)).
+</p>
+
+<p>Our policy for processing special category data can be found here:</p>
+
+<p>
+  <%= link_to(
+    "House of Commons Data Protection information - UK Parliament",
+    "https://www.parliament.uk/site-information/data-protection/commons-data-protection-information"
+  )%>
+</p>
+
+<p>
+  Details about the lawful basis for processing personal data can be found on the <%= link_to("Information Commissioner’s website.", "https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/lawful-basis-for-processing")%>
+</p>
+
+<p>
+  Unboxed Consulting Limited who provide technical support for the petitions system will also have access to the system for troubleshooting and maintenance purposes only.
+</p>
+
+<h2>4. Sharing your personal data</h2>
+
+<p>We may share or disclose your personal data with:</p>
+
+<ul>
+  <li>Suppliers and contractors of good or services contracted by House of Commons in relation to the purpose</li>
+  <li>
+    Other organisations where there is a lawful basis to do so or a duty to disclose in order to comply with any legal obligation.  For example, the Police, for the purposes of prevention and detection of crime
+  </li>
+</ul>
+
+<p>
+  We will never share or sell your personal data to other organisations for direct marketing purposes.
+</p>
+
+<h2>5. Retention and security of your personal data</h2>
+
+<p>
+  We will retain your personal data for as long as is necessary for the purpose it was collected.  In most cases, a retention period will apply which can be found in the Houses of Parliament <%= link_to("Authorised Records Disposal Policy", "https://www.parliament.uk/business/publications/parliamentary-archives/who-we-are/information-records-management-service") %> on our website.
+</p>
+
+<p>
+  In relation to Petitions, we will hold your personal data for six months after the dissolution of the current Parliament.  In connection with committee inquiries, we may lawfully retain your personal data for archiving in the public interest and this may amount to indefinite retention
+</p>
+
+<p>
+  Where the personal data held are subject to the requirements of parliamentary privilege, an individual’s rights under the UK GDPR may not apply in order to prevent an infringement of those privileges.  However, we will consider individual rights requests in relation to historic evidence on a case-by-case basis. Please also see section 6 of this notice.
+</p>
+
+<p>
+  We take the security of your data seriously. All personal data you provide to us (whether electronically or in paper form) will be stored securely in accordance with our policies. We have technical and organisational security measures in place to oversee the effective and secure processing of your personal data and to minimise the possibility of the loss or unauthorised access of your personal data.
+</p>
+
+<p>
+  Some personal data controlled by us is held outside the UK, including on data servers in the European Economic Area (EEA).  Under the Data Protection Act 2018, all countries within the EEA are regarded as providing an adequate level of data protection.  We would not transfer personal data to a person in a country outside the UK or EEA unless satisfied that that person and country had safeguards in place to protect personal data.
+</p>
+
+<h2>6. Your rights</h2>
+
+<p>
+  We will ensure you can exercise your rights in relation to the personal data you provide to us in accordance with UK GDPR and DPA 2018.  Under data protection law, you have the right to:
+</p>
+
+<ul>
+  <li>The right to be informed</li>
+  <li>The right of access</li>
+  <li>The right to rectification</li>
+  <li>The right to erasure</li>
+  <li>The right to restrict processing</li>
+  <li>The right to data portability</li>
+  <li>The right to object</li>
+  <li>Rights in relation to automated decision making and profiling.</li>
+</ul>
+
+<p>
+  Some of these rights are subject to the exceptions specified in the UK GDPR and Data Protection Act 2018, in particular:
+</p>
+
+<ul>
+  <li>
+    Parliamentary Privilege - some rights do not apply where required for the purpose of avoiding an infringement of the privileges of either House of Parliament. (para 13 of Schedule 2 DPA 2018)
+  </li>
+</ul>
+
+<p>
+  Where we are relying on your consent to use your personal data, you can withdraw that consent at any time by contacting <%= mail_to("petitionscommitteeprivacy@parliament.uk") %> or the Data Protection Officer.  However, we may take the decision to continue processing your data, even following a request by you to stop, if we consider it necessary for the purposes of our legitimate interests or those of a third party when balanced against your interests and rights.  In these circumstances you will be advised of the decision and the reason for it.
+</p>
+
+<p>If you have any concerns relating to the use of your personal data, you may complain to the Data Protection Officer. </p>
+
+<p>You also have the right to complain to the Information Commissioner, the supervisory authority, about our processing of your personal data. They can be contacted at Information Commissioner’s Office, Wycliffe House, Water Lane, Wilmslow, Cheshire, SK9 5AF</p>
+
+<p>
+  Further details about your rights can be found on the <%= link_to("Information Commissioner’s website.", "https://ico.org.uk/your-data-matters")%>
+</p>

--- a/app/views/petition_mailer/privacy_policy_update_email.text.erb
+++ b/app/views/petition_mailer/privacy_policy_update_email.text.erb
@@ -1,0 +1,131 @@
+Dear <%= @name %>
+
+We're getting in touch to let you know we’re making changes to the privacy notice for the UK Government and Parliament Petitions site (<%= home_url %>) on 1st March 2022. We are contacting you to make you aware of these changes because you have started/signed the following petitions that will be affected by these changes:
+
+<% @petitions.each do |petition| %>
+  <%= petition.action %>
+  <%= petition_url(petition) %>
+<% end %>
+<% if @remaining_petition_count > 0 %>
+  Plus another
+  <%= pluralize(@remaining_petition_count, "petition", locale: :en) %>
+<% end %>
+
+We retain your personal data for as long as is necessary for the purpose it was collected.  We will never share or sell your personal data to other organisations for direct marketing purposes.
+ 
+What's changing and why?
+
+The privacy notice has been updated. This is to ensure the privacy notice is up to date and complies with all relevant legislation, including the United Kingdom General Data Protection Regulation (UK GDPR) and Data Protection Act 2018.
+
+The House of Commons is now the sole data controller for the site. This update reflects the way that your data is stored and used.
+
+Information about cookies has been moved to a new page at https://petition.parliament.uk/cookies.
+
+How long we keep your data.  Personal data was kept for 6 months after a petition closed, but this has meant that the Petitions Committee hasn't been able to contact petitioners who opt-in to updates about their petitions when a debate has been scheduled or when other relevant Parliamentary business has taken place more than 6 months after a petition closed. This update means that from 1st March 2022, we will hold your personal data for six months after the dissolution of the current Parliament. Your data protection rights are not affected by this change and you can exercise those rights at any time as detailed in the privacy notice.
+ 
+You can read the updated privacy notice below or at <%= privacy_url %> from 1st March 2022. This includes information about how to contact us.
+
+<%= t("petitions.emails.signoff_prefix") %>
+<%= t("petitions.emails.signoff_suffix") %>
+
+Privacy Notice
+
+We respect your right to privacy and managed your personal data in line with our responsibilities under the United Kingdom General Data Protection Regulation (UK GDPR) and Data Protection Act 2018 (DPA 2018) . This privacy notice provides the information required by the UK GDPR about the personal data that we collect from you and how we may use your information.
+
+In this notice, references to 'us', 'our' or 'we' are to the House of Commons; and to ‘you’ or ‘your’ are to an individual whose personal data we process.
+
+Everything that we do with your personal data – for example, collecting, storing, using, sharing or deleting it – is referred to as 'processing'.
+
+This notice will be updated periodically.  We will communicate any significant changes as appropriate.
+
+1. About us
+
+The Corporate Officer of the House of Commons (the Clerk of the House) is the Controller of any personal data processed as described in this Privacy Notice.
+
+The House of Commons Data Protection Officer is the Head of Information Rights and Information Security (IRIS).
+
+If you have any questions about the use of your personal data, please contact IRIS:
+
+Email: IRIS@parliament.uk 
+Telephone: 0207 219 4296
+Post: IRIS Service, House of Commons, SW1A 0AA
+
+2. The personal data we process
+
+When you contact us, visit us, access or use our services either online, by post, in person or by other means, we may collect, store and use your personal data.
+
+The personal data we collect from people who start and sign petitions will include: your name, your email address, your postcode, the country you live in, whether you are a British citizen, the IP address you use when starting or signing a petition.
+
+3. Use of your personal data
+
+The Petitions service is provided by the House of Commons. Your personal data will be processed for the purposes of starting and signing petitions to raise issues with the UK Government and Parliament.
+
+We use your personal data to:
+
+check that you’re eligible to sign a petition
+make sure that people only sign a petition once
+contact you about petitions you start
+with your consent, we may send you updates about petitions you have signed.
+
+If you start a petition and we accept it, your name will be published with the petition. We won’t publish any other personal information about you. If you’ve signed a petition, we won’t publish any personal information about you. We’ll use your postcode to work out how many people in each parliamentary constituency have signed a petition.
+
+For the purpose of petitions, we consider that the lawful basis for processing your data is that we are engaged in a public task.  The processing is necessary for the performance of a public task, namely the exercise of a function of the House of Commons (UK GDPR Article 6 (1) (e) and DPA 2018 (8)).  Specifically, processing this data is necessary for the e-petitions website and the work of the Petitions Committee.
+
+For the purpose of informing you about the status of petitions, we rely on your consent to send updates to an email address provided by you (UK GDPR Article 6(1)(a)).
+
+Whilst there is no requirement to provide special category data, any information you provide which includes racial or ethnic origin; religious or philosophical beliefs; trade union membership; genetic and biometric data; health data; sex life or sexual orientation will be considered necessary for reasons of substantial public interest, namely the exercise of a function of the House of Commons (UK GDPR Article 9 (2)(g) and DPA 2018 Schedule 1 (7)(b)).
+
+Our policy for processing special category data can be found here:
+
+House of Commons Data Protection information - UK Parliament (https://www.parliament.uk/site-information/data-protection/commons-data-protection-information)
+
+Details about the lawful basis for processing personal data can be found on the Information Commissioner’s website. (https://ico.org.uk/for-organisations/guide-to-data-protection/guide-to-the-general-data-protection-regulation-gdpr/lawful-basis-for-processing)
+
+Unboxed Consulting Limited who provide technical support for the petitions system will also have access to the system for troubleshooting and maintenance purposes only.
+
+4. Sharing your personal data
+
+We may share or disclose your personal data with:
+
+Suppliers and contractors of good or services contracted by House of Commons in relation to the purpose
+
+Other organisations where there is a lawful basis to do so or a duty to disclose in order to comply with any legal obligation.  For example, the Police, for the purposes of prevention and detection of crime
+
+We will never share or sell your personal data to other organisations for direct marketing purposes.
+
+5. Retention and security of your personal data
+
+We will retain your personal data for as long as is necessary for the purpose it was collected.  In most cases, a retention period will apply which can be found in the Houses of Parliament Authorised Records Disposal Policy (https://www.parliament.uk/business/publications/parliamentary-archives/who-we-are/information-records-management-service) on our website.
+
+In relation to Petitions, we will hold your personal data for six months after the dissolution of the current Parliament.  In connection with committee inquiries, we may lawfully retain your personal data for archiving in the public interest and this may amount to indefinite retention.
+
+Where the personal data held are subject to the requirements of parliamentary privilege, an individual’s rights under the UK GDPR may not apply in order to prevent an infringement of those privileges.  However, we will consider individual rights requests in relation to historic evidence on a case-by-case basis. Please also see section 6 of this notice.
+
+We take the security of your data seriously. All personal data you provide to us (whether electronically or in paper form) will be stored securely in accordance with our policies. We have technical and organisational security measures in place to oversee the effective and secure processing of your personal data and to minimise the possibility of the loss or unauthorised access of your personal data.
+
+Some personal data controlled by us is held outside the UK, including on data servers in the European Economic Area (EEA).  Under the Data Protection Act 2018, all countries within the EEA are regarded as providing an adequate level of data protection.  We would not transfer personal data to a person in a country outside the UK or EEA unless satisfied that that person and country had safeguards in place to protect personal data.
+
+6. Your rights
+
+We will ensure you can exercise your rights in relation to the personal data you provide to us in accordance with UK GDPR and DPA 2018.  Under data protection law, you have the right to:
+
+The right to be informed
+The right of access
+The right to rectification
+The right to erasure
+The right to restrict processing
+The right to data portability
+The right to object
+Rights in relation to automated decision making and profiling.
+
+Some of these rights are subject to the exceptions specified in the UK GDPR and Data Protection Act 2018, in particular:
+
+Parliamentary Privilege - some rights do not apply where required for the purpose of avoiding an infringement of the privileges of either House of Parliament. (para 13 of Schedule 2 DPA 2018)
+
+Where we are relying on your consent to use your personal data, you can withdraw that consent at any time by contacting petitionscommitteeprivacy@parliament.uk or the Data Protection Officer.  However, we may take the decision to continue processing your data, even following a request by you to stop, if we consider it necessary for the purposes of our legitimate interests or those of a third party when balanced against your interests and rights.  In these circumstances you will be advised of the decision and the reason for it.
+
+If you have any concerns relating to the use of your personal data, you may complain to the Data Protection Officer.
+
+You also have the right to complain to the Information Commissioner, the supervisory authority, about our processing of your personal data. They can be contacted at Information Commissioner’s Office, Wycliffe House, Water Lane, Wilmslow, Cheshire, SK9 5AF
+
+Further details about your rights can be found on the Information Commissioner’s website (https://ico.org.uk/your-data-matters).

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -165,6 +165,8 @@ en-GB:
           Government responded to “%{action}”
         notify_creator_that_moderation_is_delayed: |-
           %{subject}
+        privacy_policy_update_email:  |-
+          Petitions – We're Updating Our Privacy Notice
 
         # Emails to people who support a petition
         gather_sponsors_for_petition: |-

--- a/db/migrate/20211109121106_create_privacy_notifications.rb
+++ b/db/migrate/20211109121106_create_privacy_notifications.rb
@@ -1,0 +1,9 @@
+class CreatePrivacyNotifications < ActiveRecord::Migration[6.1]
+  def change
+    create_table :privacy_notifications, id: false do |t|
+      t.primary_key :id, :uuid, null: false, default: nil
+      t.datetime :created_at, null: false
+      t.datetime :updated_at, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -556,6 +556,11 @@ ActiveRecord::Schema.define(version: 2022_01_31_160157) do
     t.index ["topics"], name: "index_petitions_on_topics", opclass: :gin__int_ops, using: :gin
   end
 
+  create_table "privacy_notifications", id: :uuid, default: nil, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "rate_limits", id: :serial, force: :cascade do |t|
     t.integer "burst_rate", default: 1, null: false
     t.integer "burst_period", default: 60, null: false

--- a/lib/tasks/petitions.rake
+++ b/lib/tasks/petitions.rake
@@ -90,8 +90,9 @@ namespace :epets do
     end
 
     desc "Email updated privacy policy"
-    task email_privacy_policy_updates: :environment do
-      EmailPrivacyPolicyUpdatesJob.perform_later
+    task :email_privacy_policy_updates, [:date] => :environment do |_task, args|
+      time = (args.time || "2021-03-01").in_time_zone
+      EmailPrivacyPolicyUpdatesJob.perform_now(time: time)
     end
   end
 end

--- a/lib/tasks/petitions.rake
+++ b/lib/tasks/petitions.rake
@@ -88,5 +88,10 @@ namespace :epets do
         end
       end
     end
+
+    desc "Email updated privacy policy"
+    task email_privacy_policy_updates: :environment do
+      EmailPrivacyPolicyUpdatesJob.perform_later
+    end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -899,4 +899,12 @@ FactoryBot.define do
       url { "https://www.gov.uk/government/organisations/department-for-international-development" }
     end
   end
+
+  factory :privacy_notification do
+    sequence(:id) do |n|
+      Digest::UUID.uuid_v5(
+        Digest::UUID::URL_NAMESPACE, "mailto:jo#{n}@public.com"
+      )
+    end
+  end
 end

--- a/spec/jobs/deliver_privacy_policy_update_job_spec.rb
+++ b/spec/jobs/deliver_privacy_policy_update_job_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe DeliverPrivacyPolicyUpdateJob, type: :job do
+  describe "perform" do
+    let(:signature) { FactoryBot.create(:signature) }
+
+    it "sends an email" do
+      expect {
+        described_class.perform_now(signature)
+      }.to change {
+        ActionMailer::Base.deliveries.count
+      }.by(1)
+    end
+  end
+end

--- a/spec/jobs/email_privacy_policy_update_job_spec.rb
+++ b/spec/jobs/email_privacy_policy_update_job_spec.rb
@@ -1,0 +1,83 @@
+require "rails_helper"
+
+RSpec.describe EmailPrivacyPolicyUpdateJob, type: :job do
+  describe "perform" do
+    context "signature validated, without matching privacy_notification" do
+      let(:petition) { FactoryBot.create(:petition) }
+
+      let!(:signature) do
+        FactoryBot.create(:validated_signature, petition: petition)
+      end
+
+      it "sends an email" do
+        expect {
+          described_class.perform_now(petition)
+        }.to change {
+          enqueued_jobs.count
+        }.by(1)
+      end
+
+      it "creates a privacy_notification record" do
+        expect {
+          described_class.perform_now(petition)
+        }.to change {
+          PrivacyNotification.count
+        }.by(1)
+      end
+    end
+
+    (Signature::STATES - [Signature::VALIDATED_STATE]).each do |state|
+      context "signature #{state}, without matching privacy_notification" do
+        let(:petition) { FactoryBot.create(:petition) }
+
+        let!(:signature) do
+          FactoryBot.create("#{state}_signature", petition: petition)
+        end
+
+        it "does no send an email" do
+          expect {
+            described_class.perform_now(petition)
+          }.not_to change {
+            enqueued_jobs.count
+          }
+        end
+
+        it "does not creates a privacy_notification record" do
+          expect {
+            described_class.perform_now(petition)
+          }.not_to change {
+            PrivacyNotification.count
+          }
+        end
+      end
+    end
+
+    context "signature validated, with matching privacy_notification" do
+      let(:petition) { FactoryBot.create(:petition) }
+
+      let!(:signature) do
+        FactoryBot.create(:validated_signature, petition: petition)
+      end
+
+      let!(:privacy_notification) do
+        FactoryBot.create(:privacy_notification, id: signature.uuid)
+      end
+
+      it "does not send an email" do
+        expect {
+          described_class.perform_now(petition)
+        }.not_to change {
+          enqueued_jobs.count
+        }
+      end
+
+      it "does not create a privacy_notification record" do
+        expect {
+          described_class.perform_now(petition)
+        }.not_to change {
+          PrivacyNotification.count
+        }
+      end
+    end
+  end
+end

--- a/spec/jobs/email_privacy_policy_updates_job_spec.rb
+++ b/spec/jobs/email_privacy_policy_updates_job_spec.rb
@@ -1,48 +1,36 @@
 require "rails_helper"
 
 RSpec.describe EmailPrivacyPolicyUpdatesJob, type: :job do
-  Petition::MODERATED_STATES.each do |state|
-    context "#{state} petition" do
-      let!(:petition) { FactoryBot.create("#{state}_petition") }
+  let(:time) { 1.year.ago }
+  let(:subject) { described_class.perform_now(time: time) }
 
-      it "enqueues job" do
-        expect {
-          described_class.perform_now
-        }.to change {
-          enqueued_jobs.count
-        }.by(1)
-      end
+  context "petition created after given time" do
+    let!(:petition) do
+      FactoryBot.create(:open_petition, created_at: time + 1.day)
     end
 
-    context "#{state} anonymized petition" do
-      let!(:petition) do
-        FactoryBot.create(
-          "#{state}_petition".to_sym,
-          anonymized_at: DateTime.current
-        )
-      end
-
-      it "does not enqueue job" do
-        expect {
-          described_class.perform_now
-        }.not_to change {
-          enqueued_jobs.count
-        }
-      end
+    it "enqueues job" do
+      expect { subject }.to change { enqueued_jobs.count }.by(1)
     end
   end
 
-  (Petition::STATES - Petition::MODERATED_STATES).each do |state|
-    context "#{state} petition" do
-      let!(:petition) { FactoryBot.create("#{state}_petition") }
+  context "petition created at given time" do
+    let!(:petition) do
+      FactoryBot.create(:open_petition, created_at: time)
+    end
 
-      it "does not enqueue job" do
-        expect {
-          described_class.perform_now
-        }.not_to change {
-          enqueued_jobs.count
-        }
-      end
+    it "enqueues job" do
+      expect { subject }.to change { enqueued_jobs.count }.by(1)
+    end
+  end
+
+  context "petition created after given time" do
+    let!(:petition) do
+      FactoryBot.create(:open_petition, created_at: time - 1.day)
+    end
+
+    it "does not enqueue job" do
+      expect { subject }.not_to change { enqueued_jobs.count }
     end
   end
 end

--- a/spec/jobs/email_privacy_policy_updates_job_spec.rb
+++ b/spec/jobs/email_privacy_policy_updates_job_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe EmailPrivacyPolicyUpdatesJob, type: :job do
+  Petition::MODERATED_STATES.each do |state|
+    context "#{state} petition" do
+      let!(:petition) { FactoryBot.create("#{state}_petition") }
+
+      it "enqueues job" do
+        expect {
+          described_class.perform_now
+        }.to change {
+          enqueued_jobs.count
+        }.by(1)
+      end
+    end
+
+    context "#{state} anonymized petition" do
+      let!(:petition) do
+        FactoryBot.create(
+          "#{state}_petition".to_sym,
+          anonymized_at: DateTime.current
+        )
+      end
+
+      it "does not enqueue job" do
+        expect {
+          described_class.perform_now
+        }.not_to change {
+          enqueued_jobs.count
+        }
+      end
+    end
+  end
+
+  (Petition::STATES - Petition::MODERATED_STATES).each do |state|
+    context "#{state} petition" do
+      let!(:petition) { FactoryBot.create("#{state}_petition") }
+
+      it "does not enqueue job" do
+        expect {
+          described_class.perform_now
+        }.not_to change {
+          enqueued_jobs.count
+        }
+      end
+    end
+  end
+end

--- a/spec/mailers/petition_mailer_spec.rb
+++ b/spec/mailers/petition_mailer_spec.rb
@@ -873,4 +873,30 @@ RSpec.describe PetitionMailer, type: :mailer do
       end
     end
   end
+
+  describe ".privacy_policy_update_email" do
+    let(:signature) { FactoryBot.create(:signature) }
+
+    let(:privacy_notification) do
+      FactoryBot.create(:privacy_notification, signature: signature)
+    end
+
+    let(:mail) do
+      described_class.privacy_policy_update_email(privacy_notification)
+    end
+
+    it "sets to" do
+      expect(mail.to).to contain_exactly(signature.email)
+    end
+
+    it "sets subject" do
+      expect(mail.subject).to eq(
+        I18n.t("petitions.emails.subjects.privacy_policy_update_email")
+      )
+    end
+
+    it "sets body" do
+      expect(mail.body.encoded).to include("Dear #{signature.name}")
+    end
+  end
 end

--- a/spec/mailers/previews/petition_mailer_preview.rb
+++ b/spec/mailers/previews/petition_mailer_preview.rb
@@ -115,4 +115,9 @@ class PetitionMailerPreview < ActionMailer::Preview
 
     PetitionMailer.notify_creator_of_debate_outcome(petition, signature)
   end
+
+  def privacy_policy_update_email
+    privacy_notification = PrivacyNotification.last
+    PetitionMailer.privacy_policy_update_email(privacy_notification)
+  end
 end

--- a/spec/models/privacy_notification_spec.rb
+++ b/spec/models/privacy_notification_spec.rb
@@ -1,0 +1,167 @@
+require 'rails_helper'
+
+RSpec.describe PrivacyNotification, type: :model do
+  it "has a valid factory" do
+    expect(FactoryBot.build(:privacy_notification)).to be_valid
+  end
+
+  describe "#petitions" do
+    Petition::MODERATED_STATES.each do |state|
+      context "signature validated, petition #{state} and not anonymized" do
+        let(:petition) { FactoryBot.create("#{state}_petition") }
+
+        let(:signature) do
+          FactoryBot.create(:validated_signature, petition: petition)
+        end
+
+        let(:privacy_notification) do
+          FactoryBot.create(:privacy_notification, signature: signature)
+        end
+
+        it "includes petition" do
+          expect(privacy_notification.petitions).to include(petition)
+        end
+      end
+    end
+
+    (Petition::STATES - Petition::MODERATED_STATES).each do |state|
+      context "signature validated, petition #{state} and not anonymized" do
+        let(:petition) { FactoryBot.create("#{state}_petition") }
+
+        let(:signature) do
+          FactoryBot.create(:validated_signature, petition: petition)
+        end
+
+        let(:privacy_notification) do
+          FactoryBot.create(:privacy_notification, signature: signature)
+        end
+
+        it "does not include petition" do
+          expect(privacy_notification.petitions).not_to include(petition)
+        end
+      end
+    end
+
+    (Signature::STATES - [Signature::VALIDATED_STATE]).each do |state|
+      context "signature #{state}, petition moderated and not anonymized" do
+        let(:petition) { FactoryBot.create(:open_petition) }
+
+        let(:signature) do
+          FactoryBot.create("#{state}_signature".to_sym, petition: petition)
+        end
+
+        let(:privacy_notification) do
+          FactoryBot.create(:privacy_notification, signature: signature)
+        end
+
+        it "does not include petition" do
+          expect(privacy_notification.petitions).not_to include(petition)
+        end
+      end
+    end
+
+    context "signature validated, petition moderated and anonymized" do
+      let(:petition) do
+        FactoryBot.create(:open_petition, anonymized_at: DateTime.current)
+      end
+
+      let(:signature) do
+        FactoryBot.create(:validated_signature, petition: petition)
+      end
+
+      let!(:privacy_notification) do
+        FactoryBot.create(:privacy_notification, signature: signature)
+      end
+
+      it "does not include petition" do
+        expect(privacy_notification.petitions).not_to include(petition)
+      end
+    end
+
+    context "more than 5 petitions" do
+      let(:privacy_notification) do
+        FactoryBot.create(
+          :privacy_notification,
+          id:  "6613a3fd-c2c4-5bc2-a6de-3dc0b2527dd6"
+        )
+      end
+
+      let!(:petitions) do
+        6.times.map do |n|
+          petition = FactoryBot.create(
+            :open_petition,
+            created_at: (6 - n).weeks.ago
+          )
+
+          petition.tap do |petition|
+            FactoryBot.create(
+              :validated_signature,
+              email: "alice@example.com",
+              petition: petition
+            )
+          end
+        end
+      end
+
+      it "only returns the 5 most recent petitions" do
+        expect(privacy_notification.petitions).to eq(petitions[1..-1].reverse)
+      end
+    end
+  end
+
+  describe "#remaining_petition_count" do
+    context "more than 5 petitions" do
+      let(:privacy_notification) do
+        FactoryBot.create(
+          :privacy_notification,
+          id:  "6613a3fd-c2c4-5bc2-a6de-3dc0b2527dd6"
+        )
+      end
+
+      let!(:petitions) do
+        6.times.map do |n|
+          petition = FactoryBot.create(:open_petition)
+
+          petition.tap do |petition|
+            FactoryBot.create(
+              :validated_signature,
+              email: "alice@example.com",
+              petition: petition
+            )
+          end
+        end
+      end
+
+      it "returns the number of remaining petitions" do
+        expect(privacy_notification.remaining_petition_count).to eq(1)
+      end
+    end
+
+    context "less than 5 petitions" do
+      let(:privacy_notification) do
+        FactoryBot.create(
+          :privacy_notification,
+          id:  "6613a3fd-c2c4-5bc2-a6de-3dc0b2527dd6"
+        )
+      end
+
+      let!(:petitions) do
+        3.times.map do |n|
+          petition = FactoryBot.create(:open_petition)
+
+          petition.tap do |petition|
+            FactoryBot.create(
+              :validated_signature,
+              email: "alice@example.com",
+              petition: petition
+            )
+          end
+        end
+      end
+
+      it "returns zero" do
+        expect(privacy_notification.remaining_petition_count).to eq(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What

- Add `#privacy_policy_update_email` to `PetitionMailer`, which sends an email to a signatory.
- ~Add `privacy_policy_update_sent` column to `signatures`.~ Create `privacy_notifications` table.
- Add `EmailPrivacyPolicyUpdateJob` which sends email to all signatures for a petition, and ~sets `privacy_policy_update_sent` to `true`.~ creates a `privacy_notification` record.
- Add `EmailPrivacyPolicyUpdatesJob` which enqueues an `EmailPrivacyPolicyUpdateJob` for every petition ~that is open or was closed/hidden/rejected in the last 6 months~ that is in a moderated state and has not been anonymized. NB This means this job has to be run AFTER the anonymization clean-up task.
- Add a rake task to enqueue `EmailPrivacyPolicyUpdatesJob`.

### Why

- Signatories who have signed petitions affected by the new privacy policy need to be notified of the changes. This includes signatories who have requested not to receive email notifications.

### To Do

- [x] Confirm whether need separate emails for creators and signers. (No)
- [x] Get copy for email(s), and confirm if needs to include list of signatory's petitions. (Yes)
- [x] Confirm subject for email(s).
- [x] Get email and policy text with updated cookie information.