### PR TITLE
Allow admins to start anonymization task for archived petitions

### DIFF
--- a/app/controllers/admin/parliaments_controller.rb
+++ b/app/controllers/admin/parliaments_controller.rb
@@ -19,6 +19,9 @@ class Admin::ParliamentsController < Admin::AdminController
       elsif archive_petitions?
         @parliament.start_archiving!
         redirect_to admin_parliament_url(tab: params[:tab]), notice: :petitions_archiving
+      elsif anonymize_petitions?
+        @parliament.start_anonymizing!
+        redirect_to admin_parliament_url(tab: params[:tab]), notice: :petitions_anonymizing
       elsif archive_parliament?
         @parliament.archive!
         redirect_to admin_parliament_url(tab: params[:tab]), notice: :parliament_archived
@@ -60,6 +63,10 @@ class Admin::ParliamentsController < Admin::AdminController
 
   def archive_petitions?
     params.key?(:archive_petitions) && @parliament.can_archive_petitions?
+  end
+
+  def anonymize_petitions?
+    params.key?(:anonymize_petitions) && Archived::Petition.can_anonymize?
   end
 
   def archive_parliament?

--- a/app/models/archived/petition.rb
+++ b/app/models/archived/petition.rb
@@ -216,6 +216,10 @@ module Archived
         removed.exists?(id)
       end
 
+      def can_anonymize?
+        where(anonymized_at: nil).where(do_not_anonymize: [nil, false]).any?
+      end
+
       private
 
       def debate_date_in_the_past(date)

--- a/app/models/parliament.rb
+++ b/app/models/parliament.rb
@@ -207,6 +207,13 @@ class Parliament < ActiveRecord::Base
     end
   end
 
+  def start_anonymizing!(now = Time.current)
+    if archiving_finished? && Archived::Petition.can_anonymize?
+      time = Date.tomorrow.beginning_of_day
+      Archived::AnonymizePetitionsJob.set(wait_until: time).perform_later(time.iso8601)
+    end
+  end
+
   def schedule_closure!
     if dissolution_announced? && !dissolved?
       ClosePetitionsEarlyJob.schedule_for(dissolution_at)

--- a/app/views/admin/parliaments/_form.html.erb
+++ b/app/views/admin/parliaments/_form.html.erb
@@ -14,6 +14,9 @@
       <%= form.submit 'Send dissolution emails', name: 'send_emails', class: 'button-secondary', data: { confirm: 'Email everyone about dissolution?' } %>
     <% end %>
   <% end %>
+  <% if Archived::Petition.can_anonymize? %>
+    <%= form.submit 'Anonymize petitions', name: 'anonymize_petitions', class: 'button-secondary', data: { confirm: 'Anonymize all archived petitions?' } %>
+  <% end %>
   <%= link_to 'Cancel', admin_root_path, class: 'button-secondary' %>
 <% end %>
 

--- a/config/locales/admin.en-GB.yml
+++ b/config/locales/admin.en-GB.yml
@@ -81,6 +81,7 @@ en-GB:
       missing_tasks: "Please select one or more tasks to execute"
       password_updated: "Password was successfully updated"
       petitions_archiving: "Archiving of petitions was successfully started"
+      petitions_anonymizing: "Anonymizing of petitions was successfully started"
       parliament_archived: "Parliament archived successfully"
       parliament_updated: "Parliament updated successfully"
       petition_email_created: "Created other parliamentary business successfully"

--- a/features/admin/anonymize_petitions.feature
+++ b/features/admin/anonymize_petitions.feature
@@ -1,0 +1,20 @@
+@admin
+Feature: An admin anonymizes petitions
+  As an admin user
+  I want to anonymize all petitions 6 months after parliament closes in accordance with our privacy policy
+
+  Background:
+    Given I am logged in as a sysadmin with the email "muddy@fox.com", first_name "Sys", last_name "Admin"
+
+  @javascript
+  Scenario: Admin anonymizes petitions 6 months after parliament closes
+    Given Parliament is dissolved and archived
+    And 2 archived petitions exist
+    When I go to the admin parliament page
+    And I press "Anonymize petitions"
+    And I accept the alert
+    Then I should see "Anonymizing of petitions was successfully started"
+
+  Scenario: An admin cannot anonymize petitions if there are none to anonymize
+    When I go to the admin parliament page
+    Then I should not see "Anonymize petitions"

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -14,14 +14,15 @@ Given(/^Parliament is dissolving$/) do
     show_dissolution_notification: true
 end
 
-Given(/^Parliament is dissolved$/) do
+Given(/^Parliament is dissolved and archived$/) do
   Parliament.instance.update! dissolution_at: 1.day.ago,
     dissolution_heading: "Parliament is dissolving",
     dissolution_message: "This means all petitions will close in 2 weeks",
     dissolved_heading: "Parliament has been dissolved",
     dissolved_message: "All petitions have been closed",
     dissolution_faq_url: "https://parliament.example.com/parliament-is-closing",
-    show_dissolution_notification: true
+    show_dissolution_notification: true,
+    archiving_started_at: 2.days.ago
 end
 
 Given(/^Parliament is pending$/) do
@@ -92,4 +93,8 @@ Then(/^I should see the Parliament dissolved warning message$/) do
     expect(page).to have_content "All petitions have been closed"
     expect(page).to have_link "Petitions Committee website", href: "https://parliament.example.com/parliament-is-closing"
   end
+end
+
+When(/^I accept the alert$/) do
+  page.driver.browser.switch_to.alert.accept
 end

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -534,3 +534,9 @@ Given(/^all the open petitions have been closed$/) do
     petition.close_early!(1.day.ago)
   end
 end
+
+Given(/^(\d+) archived petitions exist$/) do |number|
+  number.times do
+    FactoryBot.create(:archived_petition)
+  end
+end

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -134,6 +134,9 @@ module NavigationHelpers
     when /^archived petition edit details page for "([^\"]*)"$/
       admin_archived_petition_details_url(Archived::Petition.find_by(action: $1))
 
+    when /^parliament page$/
+      admin_parliament_url
+
     else
       raise "Can't find mapping from \"#{admin_page}\" to an Admin path.\n" +
         "Now, go and add a mapping in #{__FILE__}"

--- a/spec/models/archived/petition_spec.rb
+++ b/spec/models/archived/petition_spec.rb
@@ -298,6 +298,32 @@ RSpec.describe Archived::Petition, type: :model do
     end
   end
 
+  describe ".can_anonymize?" do
+    context "when there is an unanonymized petition not marked to remain anonymized" do
+      let!(:petition) { FactoryBot.create(:archived_petition, anonymized_at: nil, do_not_anonymize: nil) }
+
+      it "returns true" do
+        expect(described_class.can_anonymize?).to eq true
+      end
+    end
+
+    context "when there is an unanonymized petition marked to remain anonymized" do
+      let!(:petition) { FactoryBot.create(:archived_petition, anonymized_at: nil, do_not_anonymize: true) }
+
+      it "returns false" do
+        expect(described_class.can_anonymize?).to eq false
+      end
+    end
+
+    context "when there is one anonymized petition not marked to remain anonymized" do
+      let!(:petition) { FactoryBot.create(:archived_petition, anonymized_at: 1.day.ago, do_not_anonymize: nil) }
+
+      it "returns false" do
+        expect(described_class.can_anonymize?).to eq false
+      end
+    end
+  end
+
   describe ".anonymize_petitions!" do
     context "when a petition was rejected less than six months ago" do
       let!(:petition) do


### PR DESCRIPTION
### What 

- Adds a button on Parliament page to anonymize petitions whenever there are un-anonymized archived petitions
- Only anonymizes those that have been closed/rejected more than 6 months ago

### Why

- New data policy means that petitions will be anonymized 6 months after Parliament closes, rather than 6 months after the petition has closed. 
