### PR TITLE
Add Cookies Page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -46,4 +46,10 @@ class PagesController < ApplicationController
       format.json
     end
   end
+
+  def cookies
+    respond_to do |format|
+      format.html
+    end
+  end
 end

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -6,6 +6,7 @@
       <li><%= link_to 'Start a petition', check_petitions_path %></li>
       <li><%= link_to 'How petitions work', help_path %></li>
       <li><%= link_to 'Privacy', privacy_path %></li>
+      <li><%= link_to 'Cookies', cookies_path %></li>
       <li><%= link_to 'Feedback', feedback_path %></li>
       <li><%= link_to 'Accessibility statement', accessibility_path %></li>
     </ul>

--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -1,0 +1,45 @@
+<div class="text-page">
+  <h1>Cookies</h1>
+  <p>
+    This website puts small files (known as ‘cookies’) onto your computer to collect information about how you browse the site.
+  </p>
+  <p>
+  These essential cookies are used to:
+  </p>
+  <ul>
+    <li>remember the notifications you’ve seen so that we don’t show them to you again</li>
+    <li>help prevent people from fraudulently signing petitions</li>
+  </ul>
+  <p>
+    These cookies aren’t used to identify you personally and are strictly necessary to ensure the secure running of this website.
+  </p>
+  <p>
+    Find out more about <%= link_to('how to manage cookies', 'https://ico.org.uk/your-data-matters/online/cookies')%>.
+  </p>
+
+  <h2>
+    Session cookies
+  </h2>
+
+  <p>
+    We store a session cookie on your computer to help keep your information secure while you use the service.
+  </p>
+
+  <table>
+    <tr>
+      <th>Name</th>
+      <th>Purpose</th>
+      <th>Expires</th>
+    </tr>
+    <tr>
+      <td>_epets_session</td>
+      <td>This keeps your information secure while you use the petitions service</td>
+      <td>When you close your browser</td>
+    </tr>
+    <tr>
+      <td>signed_tokens</td>
+      <td>Randomly generated references used to identify what links you’ve clicked to verify your email address.</td>
+      <td>When you close your browser</td>
+    </tr>
+  </table>
+</div>

--- a/config/locales/page_titles.en-GB.yml
+++ b/config/locales/page_titles.en-GB.yml
@@ -35,6 +35,7 @@ en-GB:
       signed: "Thank you - Petitions"
       thank_you: "%{petition} - Thank you for supporting this petition - Petitions"
     pages:
+      cookies: "Cookies"
       index: "Petitions - UK Government and Parliament"
       help: "How petitions work"
       privacy: "Privacy notice"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
 
     controller 'pages' do
       get '/',         action: 'index', as: :home
+      get '/cookies',  action: 'cookies'
       get '/help',     action: 'help'
       get '/privacy',  action: 'privacy'
       get '/trending', action: 'trending'

--- a/features/user_sees_static_stuff.feature
+++ b/features/user_sees_static_stuff.feature
@@ -21,6 +21,13 @@ Feature: User views static pages
     And I should see "Privacy notice" in the browser page title
     And the markup should be valid
 
+  Scenario: I navigate to the Cookies page
+    When I go to the home page
+    And I follow "Cookies"
+    Then I should be on the cookies page
+    And I should see "Cookies" in the browser page title
+    And the markup should be valid
+
   Scenario: I navigate to Accessibility statement
     When I go to the home page
     And I follow "Accessibility statement"

--- a/spec/requests/disallowed_format_spec.rb
+++ b/spec/requests/disallowed_format_spec.rb
@@ -158,10 +158,18 @@ RSpec.describe 'Requests for pages when we do not support the format on that pag
     it_behaves_like 'a route that only supports html formats', headers_only: true
   end
 
-  simple_html_only_urls = [
-    'help', 'privacy', 'feedback', 'feedback/thanks', 'petitions/local',
-    'petitions/check', 'petitions/check_results', 'petitions/new'
+  simple_html_only_urls = %w[
+    help
+    privacy
+    feedback
+    feedback/thanks
+    petitions/local
+    petitions/check
+    petitions/check_results
+    petitions/new
+    cookies
   ]
+
   simple_html_only_urls.each do |simple_url|
     context "the #{simple_url} url" do
       let(:url) { "/#{simple_url}" }


### PR DESCRIPTION
### What

- Add `/cookies` route.
- Add link to 'Cookies' in footer.
- Add cookies action and view, with required text.

### Why 

Part of privacy policy update changes.

### Screenshot

<img width="50%" alt="Screenshot 2022-02-21 at 11 37 27" src="https://user-images.githubusercontent.com/25392162/154948173-30f51d72-7977-46e6-b116-f7708b9238dd.png">

